### PR TITLE
Include site stylesheet and expand news listings

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,6 +16,8 @@
   <link id="theme-style" rel="stylesheet" href="{{ $stylesheet.RelPermalink }}" integrity="{{ $stylesheet.Data.Integrity }}">
   {{- end -}}
 
+  <link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
+
   {{- partial "css-overwrite.html" . -}}
   {{- partial "syntax.html" . -}}
 

--- a/layouts/partials/page-main.html
+++ b/layouts/partials/page-main.html
@@ -10,6 +10,28 @@
 </article>
 
 {{- if .IsSection -}}
+  {{- if eq .Section "news" -}}
+<section class="news-listing">
+  <h2>{{ .Title | default (.Section | humanize) }}</h2>
+  {{- range .Pages.ByDate.Reverse -}}
+  <article class="news-item">
+    <header>
+      <h3>
+        <a href="{{ .RelPermalink }}">
+          {{- if .Date -}}
+          <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time> –
+          {{- end -}}
+          {{ .Title }}
+        </a>
+      </h3>
+    </header>
+    <div class="content">
+      {{ .Content }}
+    </div>
+  </article>
+  {{- end -}}
+</section>
+  {{- else -}}
 <section>
   <h2>{{ .Title | default (.Section | humanize) }}</h2>
   <ul>
@@ -25,6 +47,7 @@
     {{- end -}}
   </ul>
 </section>
+  {{- end -}}
 {{- else if .IsHome -}}
 <section>
   <h2>Latest Updates</h2>


### PR DESCRIPTION
## Summary
- link the static css/style.css asset from the base layout so it loads on every page
- update the news section listing to render each entry with its title and full body content

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f5e70f90832ea10df3888c0725ce