### PR TITLE
Fix dark mode toggle to update theme colors

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,4 +1,6 @@
-:root {
+:root,
+html[data-theme="light"] {
+  color-scheme: light;
   /* palette */
   --color-bg:#ffffff; --color-text:#1b1f23; --color-muted:#667085;
   --color-link:#0066ee; --color-border:#e5e7eb; --color-surface:#fafafa;
@@ -45,9 +47,38 @@
   --border-thickness: 2px;
 }
 
+html[data-theme="dark"] {
+  color-scheme: dark;
+  --color-bg:#0b1120; --color-text:#e2e8f0; --color-muted:#94a3b8;
+  --color-link:#60a5fa; --color-border:#1f2937; --color-surface:#111827;
+
+  --primary-color: #60a5fa;
+  --text-color: #e2e8f0;
+  --background-dark: #111827;
+  --white-color: #f8fafc;
+  --light-border-color: #1f2937;
+  --lighter-border-color: #374151;
+}
+
+html {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
 /* 1. Whole page */
 body {
   font: 18px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+a {
+  color: var(--color-link);
+}
+
+a:hover,
+a:focus {
+  color: color-mix(in srgb, var(--color-link) 80%, white);
 }
 
 main {


### PR DESCRIPTION
## Summary
- add dedicated light and dark color variable palettes toggled via the html data-theme attribute
- ensure the page background, text, and link colors reference the shared palette so the toggle updates the UI

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e84143985c832eaa37f5a1de47e2e1